### PR TITLE
Replace vacuum by purifier to fix the PurifierCardEditor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@ Only a native speaker can translate to a specific language.
 
 1. Clone this repo to wherever you want:
    ```sh
-   git clone https://github.com/denysdovhan/vacuum-card.git
+   git clone https://github.com/denysdovhan/purifier-card.git
    ```
 2. Go into the repo folder:
    ```sh
-   cd vacuum-card
+   cd purifier-card
    ```
 3. Install dependencies (Node.js and npm are required):
    ```sh
@@ -31,6 +31,6 @@ Only a native speaker can translate to a specific language.
    ```sh
    npm start
    ```
-5. Add `http://localhost:5000/vacuum-card.js` to your Lovelace resources.
+5. Add `http://localhost:5000/purifier-card.js` to your Lovelace resources.
 
 Now you can make changes to files in `src` folder. The development server will automatically rebuild on changes. Lovelace will load a resource from the development server. Refresh the browser to see changes. Make sure a cache is cleared or disabled.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ By default, the Home Assistant does not provide any card for controlling air pur
 
 <!-- FIXME: Replace image -->
 
-![Preview of vacuum-card][preview-image]
+![Preview of purifier-card][preview-image]
 
 ## Installing
 
@@ -119,12 +119,12 @@ Here is what every option means:
 
 You can use any attribute of purifier or even any entity by `entity_id` to display by stats section:
 
-| Name        |   Type   | Default  | Description                                        |
-| ----------- | :------: | -------- | -------------------------------------------------- |
-| `entity_id` | `string` | Optional | An entity_id with state, i.e. `sensor.vacuum_aqi`. |
-| `attribute` | `string` | Optional | Attribute name of the stat, i.e. `filter_left`.    |
-| `unit`      | `string` | Optional | Unit of measure, i.e. `hours`.                     |
-| `subtitle`  | `string` | Optional | Friendly name of the stat, i.e. `Filter`.          |
+| Name        |   Type   | Default  | Description                                          |
+| ----------- | :------: | -------- | ---------------------------------------------------- |
+| `entity_id` | `string` | Optional | An entity_id with state, i.e. `sensor.purifier_aqi`. |
+| `attribute` | `string` | Optional | Attribute name of the stat, i.e. `filter_left`.      |
+| `unit`      | `string` | Optional | Unit of measure, i.e. `hours`.                       |
+| `subtitle`  | `string` | Optional | Friendly name of the stat, i.e. `Filter`.            |
 
 ### `actions` object
 
@@ -174,7 +174,7 @@ This card supports translations. Please, help to add more translations and impro
 
 ## Supported models
 
-This card relies on basic fan services, like `toggle`, `turn_on`, `turn_off`, etc. It should work with any air purifier, however I can physically test it only with my own robot vacuum.
+This card relies on basic fan services, like `toggle`, `turn_on`, `turn_off`, etc. It should work with any air purifier, however I can physically test it only with my own purifier.
 
 If this card works with your air purifier, please open a PR and your model to the list.
 

--- a/src/purifier-card-editor.js
+++ b/src/purifier-card-editor.js
@@ -182,4 +182,4 @@ export class PurifierCardEditor extends LitElement {
   }
 }
 
-customElements.define('vacuum-card-editor', PurifierCardEditor);
+customElements.define('purifier-card-editor', PurifierCardEditor);

--- a/src/purifier-card.js
+++ b/src/purifier-card.js
@@ -25,7 +25,7 @@ class PurifierCard extends LitElement {
   }
 
   static async getConfigElement() {
-    return document.createElement('vacuum-card-editor');
+    return document.createElement('purifier-card-editor');
   }
 
   static getStubConfig(hass, entities) {


### PR DESCRIPTION
The PurifierCardEditor breaks when the "vacuum-card" is installed due to it using the same element name. This is obviously a little overlook as you just started this repo (few days ago?).

I am not sure how much of a contribution this is and this is minor (although it fixes a blocking issue for me), but thanks for both the vacuum and the purifier cards 👍 