### PR TITLE
Adding Air Purifier 2S to the list of supported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ This card relies on basic fan services, like `toggle`, `turn_on`, `turn_off`, et
 If this card works with your air purifier, please open a PR and your model to the list.
 
 - Air Purifier 3/3H
-- Air Purifier 2/2H
+- Air Purifier 2/2H/2S
 - Air Purifier Pro
 - Coway Airmega 300S/400S ([using IoCare custom component](https://github.com/sarahhenkens/home-assistant-iocare))
 - Dyson Pure Humidify+Cool ([using Dyson integration](https://www.home-assistant.io/integrations/dyson/))


### PR DESCRIPTION
Tested and working on Xiaomi Air Purifier 2S