### PR TITLE
Added tested supported model

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ If this card works with your air purifier, please open a PR and your model to th
 - Coway Airmega 300S/400S ([using IoCare custom component](https://github.com/sarahhenkens/home-assistant-iocare))
 - Dyson Pure Humidify+Cool ([using Dyson integration](https://www.home-assistant.io/integrations/dyson/))
 - Winix AM90 Wi-Fi Air Purifier
+- Philips AirPurifier AC3858/50 (partially) 
 - [_Your purifier?_][edit-readme]
 
 ## Development


### PR DESCRIPTION
The Philips AirPurifier AC3858/50 is supported by this card. The only culprits are, that there is a problem (sometimes) with setting the mode from mode dropdown - you need to set it twice to work. Also, the selected mode doesn't display right in the toolbar. I'll try to sort this out somehow.