### PR TITLE
[fix] replace old link, add additional support models

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,12 +244,14 @@ This card relies on basic fan services, like `toggle`, `turn_on`, `turn_off`, et
 
 If this card works with your air purifier, please open a PR and your model to the list.
 
+- Air Purifier 4 Pro
 - Air Purifier 3/3H
 - Air Purifier 2/2H/2S
 - Air Purifier Pro
 - Blueair Classic 480i/680i
-- Coway Airmega 300S/400S ([using IoCare custom component](https://github.com/sarahhenkens/home-assistant-iocare))
-- Dyson Pure Humidify+Cool ([using Dyson integration](https://www.home-assistant.io/integrations/dyson/))
+- Coway Airmega 300S/400S ([using IoCare custom component](https://github.com/RobertD502/home-assistant-iocare))
+- Dyson Pure Cool/Cool Link/Cool Desk/Cool Link Desk ([using Dyson custom integration](https://github.com/libdyson-wg/ha-dyson))
+- Dyson Pure Humidify+Cool ([using Dyson custom integration](https://github.com/libdyson-wg/ha-dyson))
 - Winix AM90 Wi-Fi Air Purifier
 - Philips AirPurifier AC3858/50 (partially)
 - SmartMI Air Purifier


### PR DESCRIPTION
This PR  replaces the old deprecated links for Coway and Dyson's integration with their maintained custom equivalents [[1]](https://github.com/libdyson-wg/ha-dyson) [[2]](https://github.com/RobertD502/home-assistant-iocare), as well as adding [Dyson Pure Cool series](https://www.dyson.co.th/th-TH/dyson-pure-cool-advanced-technology-tower-white-silver) and [Xiaomi (Smart) Air Purifier 4 Pro](https://www.mi.com/th/product/xiaomi-smart-air-purifier-4-pro/).

Thanks again for creating great frontend component :)