### PR TITLE
fix(shortcut): Correct isActive logic when both preset_mode and percentage are set

### DIFF
--- a/src/purifier-card.ts
+++ b/src/purifier-card.ts
@@ -361,8 +361,12 @@ export class PurifierCard extends LitElement {
 
         const isActive =
           service ||
-          percentage === attributes.percentage ||
-          preset_mode === attributes.preset_mode;
+          (percentage === attributes.percentage &&
+            attributes.preset_mode == null) ||
+          (preset_mode === attributes.preset_mode &&
+            attributes.percentage == null) ||
+          (preset_mode === attributes.preset_mode &&
+            percentage === attributes.percentage);
 
         const className = isActive ? 'active' : '';
 


### PR DESCRIPTION
I have this config:

```yaml
shortcuts:
  - name: Level 1
    icon: 'mdi:fan-speed-1'
    percentage: 33
    preset_mode: Level
  - name: Level 2
    icon: 'mdi:fan-speed-2'
    percentage: 66
    preset_mode: Level
  - name: Level 3
    icon: 'mdi:fan-speed-3'
    percentage: 100
    preset_mode: Level
```

And no matter which shortcut I click, they are all always marked as active, because the `preset_mode` is always the same. In this simple example, I could of course remove the `preset_mode`, but I also have other shortcuts and different `preset_modes`.


This change improves the logic that determines whether the purifier is active by taking into account whether `preset_mode` and/or `percentage` are explicitly set in the configuration.

✅ Previous Behavior
The isActive state was determined by checking if either percentage or preset_mode matched their corresponding attribute values. This could lead to incorrect results when both options were configured.

🔄 Updated Behavior
Now, isActive is set to true only if:

 - (same as before) `percentage` matches and `preset_mode` is not set, or
 - (same as before) `preset_mode` matches and `percentage` is not set, or
 - Both preset_mode and percentage are set and match their respective attribute values.
