### PR TITLE
fix: pass shortcut service data and target correctly

### DIFF
--- a/src/purifier-card.ts
+++ b/src/purifier-card.ts
@@ -378,7 +378,7 @@ export class PurifierCard extends LitElement {
       }) => {
         const execute = () => {
           if (service) {
-            this.callService(service, target, service_data);
+            this.callService(service, service_data ?? {}, target);
           }
 
           if (preset_mode) {


### PR DESCRIPTION
Fixes custom shortcut service calls passing `target` and `service_data` in the wrong order.

Service shortcuts now send `service_data` as service data and `target` as the Home Assistant service target.