### PR TITLE
fix: allow zero percentage shortcuts

### DIFF
--- a/src/purifier-card.ts
+++ b/src/purifier-card.ts
@@ -378,14 +378,14 @@ export class PurifierCard extends LitElement {
       }) => {
         const execute = () => {
           if (service) {
-            this.callService(service, target, service_data);
+            this.callService(service, service_data ?? {}, target);
           }
 
           if (preset_mode) {
             this.callService('fan.set_preset_mode', { preset_mode });
           }
 
-          if (percentage) {
+          if (percentage !== undefined) {
             this.callService('fan.set_percentage', { percentage });
           }
         };


### PR DESCRIPTION
Fixes percentage shortcuts with `percentage: 0` being ignored.

Zero is a valid value for `fan.set_percentage`, so the shortcut check now only skips undefined values instead of all falsy values.